### PR TITLE
Move physics simulations to fixed time step

### DIFF
--- a/Assets/Prefabs/Liquid.prefab
+++ b/Assets/Prefabs/Liquid.prefab
@@ -48,7 +48,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2977010361648334569}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_MotionVectors: 1

--- a/Assets/Prefabs/OutOfBoundsReseter.prefab
+++ b/Assets/Prefabs/OutOfBoundsReseter.prefab
@@ -12,8 +12,8 @@ GameObject:
   - component: {fileID: 2251826606862996586}
   - component: {fileID: 7892419210545797754}
   - component: {fileID: -3706924196030267556}
-  - component: {fileID: 8843016742561845941}
   - component: {fileID: 2932302414480317083}
+  - component: {fileID: 8843016742561845941}
   m_Layer: 0
   m_Name: OutOfBoundsReseter
   m_TagString: Untagged
@@ -226,36 +226,7 @@ MonoBehaviour:
         Tag06: 0
         Tag07: 0
     m_SerializedVersion: 1
-    m_BelongsTo_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CollidesWith_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CustomTags_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_IsTrigger_Deprecated:
-      m_Override: 0
-      m_Value: 0
-    m_RaisesCollisionEvents_Deprecated:
-      m_Override: 0
-      m_Value: 0
   m_SerializedVersion: 1
-  m_ConvexRadius_Deprecated: -1
---- !u!114 &8843016742561845941
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8416314409753616910}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea7d7495833204790ba1d3a8755397f8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ConversionMode: 0
 --- !u!114 &2932302414480317083
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,3 +240,16 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   resetThrowables: 1
+--- !u!114 &8843016742561845941
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8416314409753616910}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea7d7495833204790ba1d3a8755397f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ConversionMode: 0

--- a/Assets/Prefabs/PhysicsPongBall.prefab
+++ b/Assets/Prefabs/PhysicsPongBall.prefab
@@ -226,23 +226,7 @@ MonoBehaviour:
         Tag06: 0
         Tag07: 0
     m_SerializedVersion: 1
-    m_BelongsTo_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CollidesWith_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CustomTags_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_IsTrigger_Deprecated:
-      m_Override: 0
-      m_Value: 0
-    m_RaisesCollisionEvents_Deprecated:
-      m_Override: 0
-      m_Value: 0
   m_SerializedVersion: 1
-  m_ConvexRadius_Deprecated: -1
 --- !u!114 &6394926643788562501
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/PhysicsPongCup (6).prefab
+++ b/Assets/Prefabs/PhysicsPongCup (6).prefab
@@ -368,7 +368,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ccea9ea98e38942e0b0938c27ed1903e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_MotionType: 0
+  m_MotionType: 2
   m_Mass: 0.358
   m_LinearDamping: 0.01
   m_AngularDamping: 0.05

--- a/Assets/Prefabs/PhysicsPongCup (6).prefab
+++ b/Assets/Prefabs/PhysicsPongCup (6).prefab
@@ -368,7 +368,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ccea9ea98e38942e0b0938c27ed1903e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_MotionType: 2
+  m_MotionType: 0
   m_Mass: 0.358
   m_LinearDamping: 0.01
   m_AngularDamping: 0.05

--- a/Assets/Prefabs/PhysicsPongCup (6).prefab
+++ b/Assets/Prefabs/PhysicsPongCup (6).prefab
@@ -180,23 +180,7 @@ MonoBehaviour:
         Tag06: 0
         Tag07: 0
     m_SerializedVersion: 1
-    m_BelongsTo_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CollidesWith_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CustomTags_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_IsTrigger_Deprecated:
-      m_Override: 0
-      m_Value: 0
-    m_RaisesCollisionEvents_Deprecated:
-      m_Override: 0
-      m_Value: 0
   m_SerializedVersion: 1
-  m_ConvexRadius_Deprecated: -1
 --- !u!114 &6658727530279084191
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -339,23 +323,7 @@ MonoBehaviour:
         Tag06: 0
         Tag07: 0
     m_SerializedVersion: 1
-    m_BelongsTo_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CollidesWith_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CustomTags_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_IsTrigger_Deprecated:
-      m_Override: 0
-      m_Value: 0
-    m_RaisesCollisionEvents_Deprecated:
-      m_Override: 0
-      m_Value: 0
   m_SerializedVersion: 1
-  m_ConvexRadius_Deprecated: -1
 --- !u!114 &8077316870757700162
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -369,6 +337,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_MotionType: 2
+  m_Smoothing: 0
   m_Mass: 0.358
   m_LinearDamping: 0.01
   m_AngularDamping: 0.05
@@ -433,6 +402,7 @@ MonoBehaviour:
   score: 1
   deleteOnScore: 1
   cup: {fileID: 5178913366132725099}
+  water: {fileID: 6499570078321421026}
 --- !u!114 &3326734188311497615
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -453,6 +423,19 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5178913366132725099}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea7d7495833204790ba1d3a8755397f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ConversionMode: 0
+--- !u!114 &4518731808971721330
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6499570078321421026}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ea7d7495833204790ba1d3a8755397f8, type: 3}
@@ -516,6 +499,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 970c4d9e4ebab704bbee951bbcc0564c, type: 3}
+--- !u!1 &6499570078321421026 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6115251431442726448, guid: 970c4d9e4ebab704bbee951bbcc0564c, type: 3}
+  m_PrefabInstance: {fileID: 1075973601419367634}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &5870666553525760088 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6887811884677325962, guid: 970c4d9e4ebab704bbee951bbcc0564c, type: 3}

--- a/Assets/Prefabs/PhysicsPongCup.prefab
+++ b/Assets/Prefabs/PhysicsPongCup.prefab
@@ -179,23 +179,7 @@ MonoBehaviour:
         Tag06: 0
         Tag07: 0
     m_SerializedVersion: 1
-    m_BelongsTo_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CollidesWith_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CustomTags_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_IsTrigger_Deprecated:
-      m_Override: 0
-      m_Value: 0
-    m_RaisesCollisionEvents_Deprecated:
-      m_Override: 0
-      m_Value: 0
   m_SerializedVersion: 1
-  m_ConvexRadius_Deprecated: -1
 --- !u!114 &7863520373209469966
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -338,23 +322,7 @@ MonoBehaviour:
         Tag06: 0
         Tag07: 0
     m_SerializedVersion: 1
-    m_BelongsTo_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CollidesWith_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CustomTags_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_IsTrigger_Deprecated:
-      m_Override: 0
-      m_Value: 0
-    m_RaisesCollisionEvents_Deprecated:
-      m_Override: 0
-      m_Value: 0
   m_SerializedVersion: 1
-  m_ConvexRadius_Deprecated: -1
 --- !u!114 &8435804191092149489
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -368,6 +336,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_MotionType: 2
+  m_Smoothing: 0
   m_Mass: 0.358
   m_LinearDamping: 0.01
   m_AngularDamping: 0.05
@@ -431,6 +400,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   score: 10
   deleteOnScore: 1
+  cup: {fileID: 0}
 --- !u!114 &7473498504167442775
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Table.prefab
+++ b/Assets/Prefabs/Table.prefab
@@ -256,23 +256,7 @@ MonoBehaviour:
         Tag06: 0
         Tag07: 0
     m_SerializedVersion: 1
-    m_BelongsTo_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CollidesWith_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CustomTags_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_IsTrigger_Deprecated:
-      m_Override: 0
-      m_Value: 0
-    m_RaisesCollisionEvents_Deprecated:
-      m_Override: 0
-      m_Value: 0
   m_SerializedVersion: 1
-  m_ConvexRadius_Deprecated: -1
 --- !u!114 &2365494819890160004
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/ARTest.unity
+++ b/Assets/Scenes/ARTest.unity
@@ -1109,7 +1109,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b15f82cc229284894964d2d30806969d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_HumanSegmentationStencilMode: 1
+  m_HumanSegmentationStencilMode: 2
   m_HumanSegmentationDepthMode: 1
-  m_EnvironmentDepthMode: 1
-  m_OcclusionPreferenceMode: 0
+  m_EnvironmentDepthMode: 2
+  m_OcclusionPreferenceMode: 1

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -123,6 +123,197 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &322331478
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580984636793218712, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8416314409753616910, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+      propertyPath: m_Name
+      value: OutOfBoundsReseter
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f1619c7d59742467995acdd5b9a99938, type: 3}
+--- !u!1001 &394988828
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1582094862035267397, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_Name
+      value: PhysicsPongCup (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8077316870757700162, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_MotionType
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cb99c391eb19048ed94212894857a291, type: 3}
+--- !u!1001 &646708642
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6394926643788562500, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: camera
+      value: 
+      objectReference: {fileID: 963194225}
+    - target: {fileID: 6394926643788562502, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: m_Name
+      value: PhysicsPongBall
+      objectReference: {fileID: 0}
+    - target: {fileID: 6394926643788562504, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.064588
+      objectReference: {fileID: 0}
+    - target: {fileID: 6394926643788562504, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 11.34178
+      objectReference: {fileID: 0}
+    - target: {fileID: 6394926643788562504, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.9735613
+      objectReference: {fileID: 0}
+    - target: {fileID: 6394926643788562504, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6394926643788562504, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6394926643788562504, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6394926643788562504, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6394926643788562504, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6394926643788562504, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6394926643788562504, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6394926643788562504, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 24ca36a50ac17cc44bfb9dafd1718894, type: 3}
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -213,313 +404,8 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1 &776340763
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 776340769}
-  - component: {fileID: 776340768}
-  - component: {fileID: 776340767}
-  - component: {fileID: 776340766}
-  - component: {fileID: 776340765}
-  - component: {fileID: 776340764}
-  m_Layer: 0
-  m_Name: Sphere
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &776340764
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 776340763}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea7d7495833204790ba1d3a8755397f8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ConversionMode: 0
---- !u!114 &776340765
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 776340763}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ccea9ea98e38942e0b0938c27ed1903e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MotionType: 0
-  m_Mass: 1
-  m_LinearDamping: 0.01
-  m_AngularDamping: 0.05
-  m_InitialLinearVelocity:
-    x: -2
-    y: 0
-    z: 0
-  m_InitialAngularVelocity:
-    x: 0
-    y: 0
-    z: 0
-  m_GravityFactor: 1
-  m_OverrideDefaultMassDistribution: 0
-  m_CenterOfMass:
-    x: 0
-    y: 0
-    z: 0
-  m_Orientation:
-    Value:
-      x: 0
-      y: 0
-      z: 0
-    RotationOrder: 4
-  m_InertiaTensor:
-    x: 0.4
-    y: 0.4
-    z: 0.4
-  m_CustomTags:
-    Tag00: 0
-    Tag01: 0
-    Tag02: 0
-    Tag03: 0
-    Tag04: 0
-    Tag05: 0
-    Tag06: 0
-    Tag07: 0
---- !u!114 &776340766
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 776340763}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b275e5f92732148048d7b77e264ac30e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_ShapeType: 2
-  m_PrimitiveCenter:
-    x: 0
-    y: 0
-    z: 0
-  m_PrimitiveSize:
-    x: 1
-    y: 1
-    z: 1
-  m_PrimitiveOrientation:
-    Value:
-      x: -0
-      y: 0
-      z: 0
-    RotationOrder: 4
-  m_Capsule:
-    Height: 1
-    Radius: 0.5
-    Axis: 2
-  m_Cylinder:
-    Height: 1
-    Radius: 0.5
-    Axis: 2
-  m_CylinderSideCount: 20
-  m_SphereRadius: 0.5
-  m_MinimumSkinnedVertexWeight: 0.1
-  m_ConvexHullGenerationParameters:
-    m_SimplificationTolerance: 0.015
-    m_BevelRadius: 0.05
-    m_MinimumAngle: 2.5000002
-  m_CustomMesh: {fileID: 0}
-  m_ForceUnique: 0
-  m_Material:
-    m_SupportsTemplate: 1
-    m_Template: {fileID: 0}
-    m_CollisionResponse:
-      m_Override: 0
-      m_Value: 0
-    m_Friction:
-      m_Override: 0
-      m_Value:
-        Value: 0.5
-        CombineMode: 0
-    m_Restitution:
-      m_Override: 0
-      m_Value:
-        Value: 1
-        CombineMode: 2
-    m_BelongsToCategories:
-      m_Override: 0
-      m_Value:
-        Category00: 1
-        Category01: 1
-        Category02: 1
-        Category03: 1
-        Category04: 1
-        Category05: 1
-        Category06: 1
-        Category07: 1
-        Category08: 1
-        Category09: 1
-        Category10: 1
-        Category11: 1
-        Category12: 1
-        Category13: 1
-        Category14: 1
-        Category15: 1
-        Category16: 1
-        Category17: 1
-        Category18: 1
-        Category19: 1
-        Category20: 1
-        Category21: 1
-        Category22: 1
-        Category23: 1
-        Category24: 1
-        Category25: 1
-        Category26: 1
-        Category27: 1
-        Category28: 1
-        Category29: 1
-        Category30: 1
-        Category31: 1
-    m_CollidesWithCategories:
-      m_Override: 0
-      m_Value:
-        Category00: 1
-        Category01: 1
-        Category02: 1
-        Category03: 1
-        Category04: 1
-        Category05: 1
-        Category06: 1
-        Category07: 1
-        Category08: 1
-        Category09: 1
-        Category10: 1
-        Category11: 1
-        Category12: 1
-        Category13: 1
-        Category14: 1
-        Category15: 1
-        Category16: 1
-        Category17: 1
-        Category18: 1
-        Category19: 1
-        Category20: 1
-        Category21: 1
-        Category22: 1
-        Category23: 1
-        Category24: 1
-        Category25: 1
-        Category26: 1
-        Category27: 1
-        Category28: 1
-        Category29: 1
-        Category30: 1
-        Category31: 1
-    m_CustomMaterialTags:
-      m_Override: 0
-      m_Value:
-        Tag00: 0
-        Tag01: 0
-        Tag02: 0
-        Tag03: 0
-        Tag04: 0
-        Tag05: 0
-        Tag06: 0
-        Tag07: 0
-    m_SerializedVersion: 1
-    m_BelongsTo_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CollidesWith_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CustomTags_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_IsTrigger_Deprecated:
-      m_Override: 0
-      m_Value: 0
-    m_RaisesCollisionEvents_Deprecated:
-      m_Override: 0
-      m_Value: 0
-  m_SerializedVersion: 1
-  m_ConvexRadius_Deprecated: -1
---- !u!23 &776340767
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 776340763}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &776340768
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 776340763}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &776340769
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 776340763}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5.366076, y: 4.3, z: -1.3356686}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -531,6 +417,7 @@ GameObject:
   - component: {fileID: 963194228}
   - component: {fileID: 963194227}
   - component: {fileID: 963194226}
+  - component: {fileID: 963194229}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -603,6 +490,19 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &963194229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b5d0026012cd5429c9628b861609c9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 10
 --- !u!1 &1130226366
 GameObject:
   m_ObjectHideFlags: 0
@@ -856,8 +756,130 @@ Transform:
   m_LocalScale: {x: 20, y: 1, z: 20}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1743078270
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1582094862035267397, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_Name
+      value: PhysicsPongCup (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.827
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8077316870757700162, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_MotionType
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cb99c391eb19048ed94212894857a291, type: 3}
+--- !u!1001 &1829714311
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1582094862035267397, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_Name
+      value: PhysicsPongCup (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.902
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8077316870757700162, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_MotionType
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cb99c391eb19048ed94212894857a291, type: 3}
 --- !u!850595691 &1945741371
 LightingSettings:
   m_ObjectHideFlags: 0
@@ -919,3 +941,64 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaDirect: 0.5
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
+--- !u!1001 &1987146416
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1582094862035267397, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_Name
+      value: PhysicsPongCup (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.047
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763338535104507790, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8077316870757700162, guid: cb99c391eb19048ed94212894857a291, type: 3}
+      propertyPath: m_MotionType
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cb99c391eb19048ed94212894857a291, type: 3}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -249,7 +249,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8077316870757700162, guid: cb99c391eb19048ed94212894857a291, type: 3}
       propertyPath: m_MotionType
-      value: 0
+      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cb99c391eb19048ed94212894857a291, type: 3}
@@ -678,23 +678,7 @@ MonoBehaviour:
         Tag06: 0
         Tag07: 0
     m_SerializedVersion: 1
-    m_BelongsTo_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CollidesWith_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CustomTags_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_IsTrigger_Deprecated:
-      m_Override: 0
-      m_Value: 0
-    m_RaisesCollisionEvents_Deprecated:
-      m_Override: 0
-      m_Value: 0
   m_SerializedVersion: 1
-  m_ConvexRadius_Deprecated: -1
 --- !u!23 &1130226369
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -815,7 +799,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8077316870757700162, guid: cb99c391eb19048ed94212894857a291, type: 3}
       propertyPath: m_MotionType
-      value: 0
+      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cb99c391eb19048ed94212894857a291, type: 3}
@@ -876,7 +860,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8077316870757700162, guid: cb99c391eb19048ed94212894857a291, type: 3}
       propertyPath: m_MotionType
-      value: 0
+      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cb99c391eb19048ed94212894857a291, type: 3}
@@ -998,7 +982,52 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8077316870757700162, guid: cb99c391eb19048ed94212894857a291, type: 3}
       propertyPath: m_MotionType
-      value: 0
+      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cb99c391eb19048ed94212894857a291, type: 3}
+--- !u!1 &2122838829
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2122838831}
+  - component: {fileID: 2122838830}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2122838830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2122838829}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 506bde10195177e4bb893eab14f4b1b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scoreText: {fileID: 0}
+  tablePlaced: 0
+--- !u!4 &2122838831
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2122838829}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.1193651, y: 1.5203915, z: 0.44116116}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/ThrowDemonstration.unity
+++ b/Assets/Scenes/ThrowDemonstration.unity
@@ -213,7 +213,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!1 &963194225
 GameObject:
@@ -296,7 +296,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1130226366
 GameObject:
@@ -473,23 +473,7 @@ MonoBehaviour:
         Tag06: 0
         Tag07: 0
     m_SerializedVersion: 1
-    m_BelongsTo_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CollidesWith_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_CustomTags_Deprecated:
-      m_Override: 0
-      m_Value: 
-    m_IsTrigger_Deprecated:
-      m_Override: 0
-      m_Value: 0
-    m_RaisesCollisionEvents_Deprecated:
-      m_Override: 0
-      m_Value: 0
   m_SerializedVersion: 1
-  m_ConvexRadius_Deprecated: -1
 --- !u!23 &1130226369
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -551,7 +535,7 @@ Transform:
   m_LocalScale: {x: 50, y: 1, z: 50}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1382768514
 GameObject:

--- a/Assets/Scripts/Behaviours/GameManager.cs
+++ b/Assets/Scripts/Behaviours/GameManager.cs
@@ -31,7 +31,13 @@ public class GameManager : MonoBehaviour
         DisplayScore();
     }
     private void DisplayScore(){
-        scoreText.text = $"Cups left: { World.DefaultGameObjectInjectionWorld}";
+        if (scoreText)
+            scoreText.text = $"Cups left: { curScore}";
+    }
+
+    private void Update() {
+        //TODO: add code for unity fixed timestep here
+        //should match server tick rate when we get photon going    
     }
 
     public void IncreaseScore() {
@@ -39,7 +45,7 @@ public class GameManager : MonoBehaviour
         DisplayScore();
         if(curScore == 0){
             // disable fixed rate before scene switch to avoid crashes
-            FixedRateUtils.DisableFixedRate(World.DefaultGameObjectInjectionWorld.GetOrCreateSystem<SimulationSystemGroup>());
+            //FixedRateUtils.DisableFixedRate(World.DefaultGameObjectInjectionWorld.GetOrCreateSystem<SimulationSystemGroup>());
             //DESTROY BALL
             EntityManager em = World.DefaultGameObjectInjectionWorld.EntityManager;
             em.DestroyEntity(em.UniversalQuery);

--- a/Assets/Scripts/Behaviours/GameManager.cs
+++ b/Assets/Scripts/Behaviours/GameManager.cs
@@ -38,6 +38,8 @@ public class GameManager : MonoBehaviour
         curScore = curScore -1;
         DisplayScore();
         if(curScore == 0){
+            // disable fixed rate before scene switch to avoid crashes
+            FixedRateUtils.DisableFixedRate(World.DefaultGameObjectInjectionWorld.GetOrCreateSystem<SimulationSystemGroup>());
             //DESTROY BALL
             EntityManager em = World.DefaultGameObjectInjectionWorld.EntityManager;
             em.DestroyEntity(em.UniversalQuery);

--- a/Assets/Scripts/Behaviours/GameStateManagementSystem.cs
+++ b/Assets/Scripts/Behaviours/GameStateManagementSystem.cs
@@ -10,7 +10,7 @@ public enum GameStates
     Lost
 }
 
-[UpdateAfter(typeof(TargetScoringSystem))] //update after score checking
+[UpdateAfter(typeof(FixedStepSimulationSystemGroup))] //update after score checking
 public class GameStateManagementSystem : SystemBase
 {
 

--- a/Assets/Scripts/Component Systems/PhysicsFixedRateHack.cs
+++ b/Assets/Scripts/Component Systems/PhysicsFixedRateHack.cs
@@ -1,0 +1,16 @@
+﻿using Unity.Entities;
+
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public class PhysicsFixedRateHack : SystemBase
+{
+  private bool _IsInitialized;
+
+  protected override void OnUpdate() {
+      if(!_IsInitialized){
+          FixedRateUtils.EnableFixedRateWithCatchUp(
+              World.GetOrCreateSystem<SimulationSystemGroup>(),
+              UnityEngine.Time.fixedDeltaTime);
+              _IsInitialized = true;
+      }
+  }
+}

--- a/Assets/Scripts/Component Systems/PhysicsFixedRateHack.cs
+++ b/Assets/Scripts/Component Systems/PhysicsFixedRateHack.cs
@@ -1,16 +1,18 @@
 ﻿using Unity.Entities;
+using UnityEngine;
 
-[UpdateInGroup(typeof(SimulationSystemGroup))]
-public class PhysicsFixedRateHack : SystemBase
-{
-  private bool _IsInitialized;
+// [UpdateInGroup(typeof(SimulationSystemGroup))]
+// public class PhysicsFixedRateHack : SystemBase
+// {
+//   private bool _IsInitialized;
 
-  protected override void OnUpdate() {
-      if(!_IsInitialized){
-          FixedRateUtils.EnableFixedRateWithCatchUp(
-              World.GetOrCreateSystem<SimulationSystemGroup>(),
-              UnityEngine.Time.fixedDeltaTime);
-              _IsInitialized = true;
-      }
-  }
-}
+//   protected override void OnUpdate() {
+//       if(!_IsInitialized){
+//           Debug.Log(typeof(SimulationSystemGroup));
+//               FixedRateUtils.EnableFixedRateWithCatchUp(World.GetOrCreateSystem<SimulationSystemGroup>(),
+//                                     UnityEngine.Time.fixedDeltaTime);
+//               _IsInitialized = true;
+//       }
+//       Debug.Log(UnityEngine.Time.time);
+//   }
+// }

--- a/Assets/Scripts/Component Systems/PhysicsFixedRateHack.cs.meta
+++ b/Assets/Scripts/Component Systems/PhysicsFixedRateHack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41b5d56b160584165a037b6931237e1f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Component Systems/ResetStoppedThrowableSystem.cs
+++ b/Assets/Scripts/Component Systems/ResetStoppedThrowableSystem.cs
@@ -8,17 +8,19 @@ using Unity.Physics.Systems;
 public class ResetStoppedThrowableSystem : SystemBase
 {
     EndFixedStepSimulationEntityCommandBufferSystem bufferSystem;
+    static float3 velocityLimit;
 
     protected override void OnCreate()
     {
         bufferSystem = World.GetOrCreateSystem<EndFixedStepSimulationEntityCommandBufferSystem>();
+        velocityLimit = new float3(0.1f, 0.1f, 0.1f);
     }
     protected override void OnUpdate()
     {
         EntityCommandBuffer commandBuffer = bufferSystem.CreateCommandBuffer();
         Entities.ForEach((ref Entity e, ref Throwable throwable, ref PhysicsVelocity velocity) => {
             if(throwable.thrown) {
-                if(math.abs(velocity.Linear).Equals(float3.zero)) {
+                if((math.abs(velocity.Linear.x) <= velocityLimit.x) && (math.abs(velocity.Linear.y) <= velocityLimit.y) && (math.abs(velocity.Linear.z) <= velocityLimit.z)) {
                     //reset throwable
                     commandBuffer.AddComponent(e, new ResetTag());
                 }

--- a/Assets/Scripts/Component Systems/ResetStoppedThrowableSystem.cs
+++ b/Assets/Scripts/Component Systems/ResetStoppedThrowableSystem.cs
@@ -1,0 +1,28 @@
+﻿using Unity.Entities;
+using Unity.Physics;
+using Unity.Mathematics;
+using Unity.Physics.Systems;
+
+[UpdateInGroup(typeof(FixedStepSimulationSystemGroup))]
+[UpdateAfter(typeof(EndFramePhysicsSystem))]
+public class ResetStoppedThrowableSystem : SystemBase
+{
+    EndFixedStepSimulationEntityCommandBufferSystem bufferSystem;
+
+    protected override void OnCreate()
+    {
+        bufferSystem = World.GetOrCreateSystem<EndFixedStepSimulationEntityCommandBufferSystem>();
+    }
+    protected override void OnUpdate()
+    {
+        EntityCommandBuffer commandBuffer = bufferSystem.CreateCommandBuffer();
+        Entities.ForEach((ref Entity e, ref Throwable throwable, ref PhysicsVelocity velocity) => {
+            if(throwable.thrown) {
+                if(math.abs(velocity.Linear).Equals(float3.zero)) {
+                    //reset throwable
+                    commandBuffer.AddComponent(e, new ResetTag());
+                }
+            }
+        }).Run();   
+    }
+}

--- a/Assets/Scripts/Component Systems/ResetStoppedThrowableSystem.cs.meta
+++ b/Assets/Scripts/Component Systems/ResetStoppedThrowableSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 011a55963e94a4dea859015b975721df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Component Systems/ResetThrowableSystem.cs
+++ b/Assets/Scripts/Component Systems/ResetThrowableSystem.cs
@@ -6,7 +6,8 @@ using Unity.Mathematics;
 using Unity.Physics.Systems;
 using UnityEngine;
 
-[UpdateAfter(typeof(EndFramePhysicsSystem))] //update after simulation has ran for the frame
+[UpdateInGroup(typeof(FixedStepSimulationSystemGroup))] //update after simulation has ran for the frame
+[UpdateAfter(typeof(EndFramePhysicsSystem))] // run after simulation is done for frame
 public class ResetThrowableSystem : SystemBase
 {
     BuildPhysicsWorld buildPhysicsWorld;

--- a/Assets/Scripts/Component Systems/TargetScoringSystem.cs
+++ b/Assets/Scripts/Component Systems/TargetScoringSystem.cs
@@ -6,7 +6,8 @@ using Unity.Mathematics;
 using Unity.Physics.Systems;
 using UnityEngine;
 
-[UpdateAfter(typeof(EndFramePhysicsSystem))] //update after simulation has been run for the frame
+[UpdateInGroup(typeof(FixedStepSimulationSystemGroup))]
+[UpdateAfter(typeof(EndFramePhysicsSystem))] // run after simulation is done for frame
 public class TargetScoringSystem : SystemBase
 {
     BuildPhysicsWorld buildPhysicsWorld;

--- a/Assets/Scripts/Component Systems/TargetScoringSystem.cs
+++ b/Assets/Scripts/Component Systems/TargetScoringSystem.cs
@@ -91,6 +91,7 @@ public class TargetScoringSystem : SystemBase
             //remove cup if it should be deleted;
             if (goalComponent.deleteOnScore)
             {
+                //commandBuffer.DestroyEntity(goalComponent.water);
                 commandBuffer.DestroyEntity(goalComponent.cup);
                 commandBuffer.AddComponent(goalEntity, new DeleteTag()); // tag for score increment/deletion
                 

--- a/Assets/Scripts/Component Systems/ThrowMotionSystem.cs
+++ b/Assets/Scripts/Component Systems/ThrowMotionSystem.cs
@@ -14,6 +14,18 @@ public class ThrowMotionSystem : SystemBase
 
     protected override void OnUpdate()
     {
+        //check for throwables with 0 velocity, and reset them
+        EntityManager entityManager = World.DefaultGameObjectInjectionWorld.EntityManager;
+        Entities.WithAll<ResetTag>().WithStructuralChanges().ForEach((ref Entity e, ref PhysicsVelocity velocity, ref Throwable throwable) =>
+        {
+            if (throwable.thrown)
+            {
+                throwable.thrown = !throwable.thrown;
+                entityManager.RemoveComponent(e, typeof(PhysicsMass));
+                entityManager.RemoveComponent(e, typeof(ResetTag));
+                velocity.Linear = new float3(0, 0, 0);
+            }
+        }).Run();
         return;
     }
 
@@ -34,7 +46,7 @@ public class ThrowMotionSystem : SystemBase
             Camera cameraData = Camera.main;
             //var cameraData = entityManager.GetComponentObject<Camera>(t.camera);
             var camDirection = cameraData.transform.forward;
-    
+
 
             entityManager.AddComponentData(e, new PhysicsVelocity
             {
@@ -50,12 +62,12 @@ public class ThrowMotionSystem : SystemBase
     public void Reset()
     {
         EntityManager entityManager = World.DefaultGameObjectInjectionWorld.EntityManager;
-        Entities.WithStructuralChanges().ForEach((ref Entity e,ref PhysicsVelocity velocity, ref Throwable throwable) =>
+        Entities.WithStructuralChanges().ForEach((ref Entity e, ref PhysicsVelocity velocity, ref Throwable throwable) =>
         {
             if (throwable.thrown)
             {
                 throwable.thrown = !throwable.thrown;
-                EntityManager.RemoveComponent(e, typeof(PhysicsMass));
+                entityManager.RemoveComponent(e, typeof(PhysicsMass));
                 velocity.Linear = new float3(0, 0, 0);
             }
         }).Run();

--- a/Assets/Scripts/Component Systems/ThrowMotionSystem.cs
+++ b/Assets/Scripts/Component Systems/ThrowMotionSystem.cs
@@ -3,6 +3,7 @@ using Unity.Jobs;
 using Unity.Transforms;
 using Unity.Mathematics;
 using Unity.Physics;
+using Unity.Physics.GraphicsIntegration;
 using UnityEngine;
 
 /**
@@ -43,6 +44,9 @@ public class ThrowMotionSystem : SystemBase
             //add physics mass to entity
             t.thrown = true;
             entityManager.AddComponentData(e, PhysicsMass.CreateDynamic(collider.MassProperties, t.mass / 1000));
+            entityManager.AddComponentData(e, new PhysicsGraphicalSmoothing {
+                ApplySmoothing = 1,
+            });
         }).Run();
     }
 

--- a/Assets/Scripts/DataTypes/ResetTag.cs
+++ b/Assets/Scripts/DataTypes/ResetTag.cs
@@ -1,0 +1,7 @@
+using Unity.Entities;
+
+[GenerateAuthoringComponent]
+
+public struct ResetTag : IComponentData
+{
+}

--- a/Assets/Scripts/DataTypes/ResetTag.cs.meta
+++ b/Assets/Scripts/DataTypes/ResetTag.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66c4f641915634c4aba27b6051f4b5ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/DataTypes/ScoringCollider.cs
+++ b/Assets/Scripts/DataTypes/ScoringCollider.cs
@@ -6,5 +6,5 @@ public struct ScoringCollider:IComponentData {
     public int score;
     public bool deleteOnScore;
     public Entity cup;
-    public Entity water;
+    // public Entity water;
 }

--- a/Assets/Scripts/DataTypes/ScoringCollider.cs
+++ b/Assets/Scripts/DataTypes/ScoringCollider.cs
@@ -6,4 +6,5 @@ public struct ScoringCollider:IComponentData {
     public int score;
     public bool deleteOnScore;
     public Entity cup;
+    public Entity water;
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -4,7 +4,7 @@
     "com.unity.ide.rider": "1.2.1",
     "com.unity.ide.visualstudio": "2.0.2",
     "com.unity.ide.vscode": "1.2.2",
-    "com.unity.physics": "0.4.1-preview",
+    "com.unity.physics": "0.5.1-preview.2",
     "com.unity.rendering.hybrid": "0.8.0-preview.19",
     "com.unity.test-framework": "1.1.16",
     "com.unity.textmeshpro": "3.0.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "com.unity.burst": {
-      "version": "1.3.2",
-      "depth": 2,
+      "version": "1.3.7",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.mathematics": "1.1.0"
+        "com.unity.mathematics": "1.2.1"
       },
       "url": "https://packages.unity.com"
     },
@@ -17,12 +17,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collections": {
-      "version": "0.12.0-preview.13",
-      "depth": 2,
+      "version": "0.14.0-preview.16",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.test-framework.performance": "2.3.1-preview",
-        "com.unity.burst": "1.3.2"
+        "com.unity.burst": "1.3.7"
       },
       "url": "https://packages.unity.com"
     },
@@ -34,20 +34,21 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.entities": {
-      "version": "0.14.0-preview.19",
+      "version": "0.16.0-preview.21",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.burst": "1.3.2",
-        "com.unity.collections": "0.12.0-preview.13",
-        "com.unity.properties": "1.3.1-preview",
-        "com.unity.mathematics": "1.1.0",
+        "com.unity.burst": "1.3.7",
+        "com.unity.properties": "1.5.0-preview",
+        "com.unity.serialization": "1.5.0-preview",
+        "com.unity.collections": "0.14.0-preview.16",
+        "com.unity.mathematics": "1.2.1",
+        "com.unity.modules.assetbundle": "1.0.0",
         "com.unity.test-framework.performance": "2.3.1-preview",
-        "com.unity.serialization": "1.3.1-preview",
         "com.unity.nuget.mono-cecil": "0.1.6-preview.2",
-        "com.unity.jobs": "0.5.0-preview.14",
+        "com.unity.jobs": "0.7.0-preview.17",
         "com.unity.scriptablebuildpipeline": "1.9.0",
-        "com.unity.platforms": "0.7.0-preview.8"
+        "com.unity.platforms": "0.9.0-preview.9"
       },
       "url": "https://packages.unity.com"
     },
@@ -82,17 +83,17 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.jobs": {
-      "version": "0.5.0-preview.14",
-      "depth": 2,
+      "version": "0.7.0-preview.17",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.collections": "0.12.0-preview.13",
-        "com.unity.mathematics": "1.1.0"
+        "com.unity.collections": "0.14.0-preview.16",
+        "com.unity.mathematics": "1.2.1"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.mathematics": {
-      "version": "1.1.0",
+      "version": "1.2.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -115,52 +116,52 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.physics": {
-      "version": "0.4.1-preview",
+      "version": "0.5.1-preview.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.burst": "1.3.0",
-        "com.unity.collections": "0.9.0-preview.6",
-        "com.unity.entities": "0.11.1-preview.4",
-        "com.unity.jobs": "0.2.10-preview.12",
-        "com.unity.mathematics": "1.1.0",
+        "com.unity.burst": "1.3.7",
+        "com.unity.collections": "0.14.0-preview.16",
+        "com.unity.entities": "0.16.0-preview.21",
+        "com.unity.jobs": "0.7.0-preview.17",
+        "com.unity.mathematics": "1.2.1",
         "com.unity.test-framework": "1.1.11",
-        "com.unity.test-framework.performance": "2.2.0-preview",
+        "com.unity.test-framework.performance": "2.3.1-preview",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.platforms": {
-      "version": "0.7.0-preview.8",
+      "version": "0.9.0-preview.9",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.unity.properties": "1.3.1-preview",
-        "com.unity.properties.ui": "1.3.1-preview",
+        "com.unity.properties": "1.5.0-preview",
+        "com.unity.properties.ui": "1.5.0-preview",
         "com.unity.scriptablebuildpipeline": "1.6.4-preview",
-        "com.unity.searcher": "4.0.9",
-        "com.unity.serialization": "1.3.1-preview"
+        "com.unity.serialization": "1.5.0-preview"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.properties": {
-      "version": "1.3.1-preview",
+      "version": "1.5.0-preview",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "nuget.mono-cecil": "0.1.5-preview",
+        "com.unity.nuget.mono-cecil": "0.1.6-preview.2",
         "com.unity.test-framework.performance": "2.0.8-preview"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.properties.ui": {
-      "version": "1.3.1-preview",
+      "version": "1.5.0-preview",
       "depth": 3,
       "source": "registry",
       "dependencies": {
-        "com.unity.properties": "1.3.1-preview",
-        "com.unity.serialization": "1.3.1-preview"
+        "com.unity.properties": "1.5.0-preview",
+        "com.unity.serialization": "1.5.0-preview",
+        "com.unity.modules.uielements": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -180,22 +181,15 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
-    "com.unity.searcher": {
-      "version": "4.0.9",
-      "depth": 3,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.serialization": {
-      "version": "1.3.1-preview",
+      "version": "1.5.0-preview",
       "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.unity.collections": "0.8.0-preview.5",
         "com.unity.burst": "1.3.0-preview.12",
         "com.unity.jobs": "0.2.9-preview.15",
-        "com.unity.properties": "1.3.1-preview",
+        "com.unity.properties": "1.4.3-preview",
         "com.unity.test-framework.performance": "2.0.8-preview"
       },
       "url": "https://packages.unity.com"
@@ -222,7 +216,7 @@
     },
     "com.unity.test-framework.performance": {
       "version": "2.3.1-preview",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.test-framework": "1.1.0",


### PR DESCRIPTION
What's been done:
- Updates `Unity.Physics` package to version `0.5.1-preview.2`, which moves all simulations to a fixed time step, instead of updating every frame. This makes our physics framerate independent.
- Updates Systems that run alongside the physics simulation (`TargetScoringSystem` and `ResetThrowableSystem`) to also run on the fixed time step
- Updated the physics data. If you get issues related to physics data when trying to run the sample scene, try selecting Window > DOTS > Physics > Upgrade Data.
- Added some basic functionality to the sample scene. This is for debugging any physics system without needing to compile to a device.
- Added a small comment in `GameManager`. Which is where (I think) we need to write some code to ensure that the simulation update frequency matches the server tick rate for multiplayer.
- Made cups dynamic again. I haven't tested FPS with the fixed time step, so I'll leave them as static for now.

The PR is tested with the gameplay loop present on the current master branch

TL;DR: Moved physics to a fixed timestep. This is needed for multiplayer to work well, and makes the simulations deterministic.